### PR TITLE
Added docker-compose for external services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,49 @@
-demo for use of WebSockets 
+demo for use of WebSockets
 the idea is to allow push notifications to be sent from Elastic to the middleware (Python: FastAPI) and then on up to the UI (JavaScript: Svelte), in order to avoid the UI having to constantly poll the middleware which then has to constantly poll Elastic in response (or perform some kind of caching)
 
 progress so far:
-* UI opens a WS to the middleware, and subscribes to messages coming from it
-* UI sends a boolean down the WS to the middleware to toggle on/off each channel individually
-* MetricBeats is running, populating Elastic with system stats
-* multiple parallel independent components in the UI (each subscribed to their own backend data feed)
-* installed an Elastic plugin which pushes change notifications out on a websocket - requires Elastic and Kibana 6.5.3, so installed them also (instead of latest version 7.15.1) 
-* installed the plugin into Elastic (and then restarted Elastic) which can't be done easily with Elastic running inside a Docker container (so actually installed Elastic and Kibana)
-* used default config for the plugin, to push all updates out to the WS, seems to be fine as-is (for this demo at least)
-* changed the Python code to use the WS (instead of polling Elastic)
-* totally removed the logic (to determine when the backend status has changed) as the Elastic plugin does this for us now
-* totally removed all polling of Elastic from the middleware, and all polling of the middleware from the UI
 
+- UI opens a WS to the middleware, and subscribes to messages coming from it
+- UI sends a boolean down the WS to the middleware to toggle on/off each channel individually
+- MetricBeats is running, populating Elastic with system stats
+- multiple parallel independent components in the UI (each subscribed to their own backend data feed)
+- installed an Elastic plugin which pushes change notifications out on a websocket - requires Elastic and Kibana 6.5.3, so installed them also (instead of latest version 7.15.1)
+- installed the plugin into Elastic (and then restarted Elastic) which can't be done easily with Elastic running inside a Docker container (so actually installed Elastic and Kibana)
+- used default config for the plugin, to push all updates out to the WS, seems to be fine as-is (for this demo at least)
+- changed the Python code to use the WS (instead of polling Elastic)
+- totally removed the logic (to determine when the backend status has changed) as the Elastic plugin does this for us now
+- totally removed all polling of Elastic from the middleware, and all polling of the middleware from the UI
 
 to start the UI:
-    npm run dev
-
+npm run dev
 
 to start Python server:
-    cd src; uvicorn main:app
+cd src; uvicorn main:app
 
-
-to install *** VERSION: 6.5.3 *** of Elastic, Kibana, Metricbeat
-    echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | sudo tee –a /etc/apt/sources.list.d/elastic-6.x.list
-    apt update
-    apt install elasticsearch=6.5.3
-    apt install kibana=6.5.3
-    cd /tmp
-    wget https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-6.5.3-amd64.deb
-    dpkg -i /tmp/metricbeat-6.5.3-amd64.deb
-
+to install **_ VERSION: 6.5.3 _** of Elastic, Kibana, Metricbeat
+echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | sudo tee –a /etc/apt/sources.list.d/elastic-6.x.list
+apt update
+apt install elasticsearch=6.5.3
+apt install kibana=6.5.3
+cd /tmp
+wget https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-6.5.3-amd64.deb
+dpkg -i /tmp/metricbeat-6.5.3-amd64.deb
 
 to install the plugin
-    git clone https://github.com/ForgeRock/es-change-feed-plugin.git
-    cd es-change-feed-plugin
-    mvn clean install  
-    mkdir /tmp/elasticsearch
-    cp target/es-changes-feed-plugin.zip /tmp/elasticsearch
-    cd /tmp/elasticsearch
-    unzip es-changes-feed-plugin.zip 
-    cd ..
-    zip -r es-changes-feed-plugin.zip elasticsearch
-    # requires Elastic to be running first
-    /usr/share/elasticsearch/bin/elasticsearch-plugin install file:///tmp/es-changes-feed-plugin.zip
-    systemctl restart elastic 
-
+git clone https://github.com/ForgeRock/es-change-feed-plugin.git
+cd es-change-feed-plugin
+mvn clean install  
+ mkdir /tmp/elasticsearch
+cp target/es-changes-feed-plugin.zip /tmp/elasticsearch
+cd /tmp/elasticsearch
+unzip es-changes-feed-plugin.zip
+cd ..
+zip -r es-changes-feed-plugin.zip elasticsearch # requires Elastic to be running first
+/usr/share/elasticsearch/bin/elasticsearch-plugin install file:///tmp/es-changes-feed-plugin.zip
+systemctl restart elastic
 
 to run the demo:
-    
+
     start Python server:
         cd src; uvicorn main:app
 
@@ -67,26 +62,33 @@ to run the demo:
         /usr/bin/metricbeat setup -e
         systemctl start metricbeat
 
+## Run all services using docker-compose
 
+All services depicted below can be run using docker-compose:
 
-# miscellaneous useful commands 
+- To bring up all services: `docker-compose up -d`
+- To bin down all services: `docker-compose down`
 
-# run elastic
-docker run --memory=2gb --name es01-test --net elastic -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.15.2
+### Run Elastic
 
-# run rabbitmq
-docker run --memory=500mb -it --rm --name rabbitmq -p 5672:5672 -p 15672:15672 -p 15674:15674 -p 15670:15670 rabbitmq:3.9-management
+`docker run --memory=2gb --name es01-test --net elastic -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.15.2`
 
-# run kibana
-docker run --memory=2gb --name kib01-test --volume="$(pwd)/kibana.yml:/usr/share/kibana/config/kibana.yml:ro" --net elastic -p 5601:5601 -e "ELASTICSEARCH_HOSTS=http://es01-test:9200" docker.elastic.co/kibana/kibana:7.15.2
+### Run RabbitMQ
 
-# run metricbeat
-docker run --memory=500mb docker.elastic.co/beats/metricbeat:7.15.2 setup -E setup.kibana.host=< LOCAL IP >:5601 -E output.elasticsearch.hosts=["http://< LOCAL IP >:9200"]
+`docker run --memory=500mb -it --rm --name rabbitmq -p 5672:5672 -p 15672:15672 -p 15674:15674 -p 15670:15670 rabbitmq:3.9-management`
 
-# run metricbeat, with config (metricbeat.yml)
-docker run --name=metricbeat --user=root --volume="$(pwd)/metricbeat.docker.yml:/usr/share/metricbeat/metricbeat.yml:ro" --volume="/var/run/docker.sock:/var/run/docker.sock:ro" --volume="/sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro" --volume="/proc:/hostfs/proc:ro" --volume="/:/hostfs:ro" docker.elastic.co/beats/metricbeat:7.15.2 metricbeat -e -E output.elasticsearch.hosts=["< LOCAL IP >:9200"]
+### Run Kibana
 
-# tell metricbeat to monitor the host machine
-docker run --mount type=bind,source=/proc,target=/hostfs/proc,readonly --mount type=bind,source=/sys/fs/cgroup,target=/hostfs/sys/fs/cgroup,readonly --mount type=bind,source=/,target=/hostfs,readonly --net=host docker.elastic.co/beats/metricbeat:7.15.2 -e -system.hostfs=/hostfs
+`docker run --memory=2gb --name kib01-test --volume="$(pwd)/kibana.yml:/usr/share/kibana/config/kibana.yml:ro" --net elastic -p 5601:5601 -e "ELASTICSEARCH_HOSTS=http://es01-test:9200" docker.elastic.co/kibana/kibana:7.15.2`
 
+### Run Metricbeat
 
+`docker run --memory=500mb docker.elastic.co/beats/metricbeat:7.15.2 setup -E setup.kibana.host=< LOCAL IP >:5601 -E output.elasticsearch.hosts=["http://< LOCAL IP >:9200"]`
+
+### Run Metricbeat, with config (metricbeat.yml)
+
+`docker run --name=metricbeat --user=root --volume="$(pwd)/metricbeat.docker.yml:/usr/share/metricbeat/metricbeat.yml:ro" --volume="/var/run/docker.sock:/var/run/docker.sock:ro" --volume="/sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro" --volume="/proc:/hostfs/proc:ro" --volume="/:/hostfs:ro" docker.elastic.co/beats/metricbeat:7.15.2 metricbeat -e -E output.elasticsearch.hosts=["< LOCAL IP >:9200"]`
+
+### Tell Metricbeat to monitor the host machine
+
+`docker run --mount type=bind,source=/proc,target=/hostfs/proc,readonly --mount type=bind,source=/sys/fs/cgroup,target=/hostfs/sys/fs/cgroup,readonly --mount type=bind,source=/,target=/hostfs,readonly --net=host docker.elastic.co/beats/metricbeat:7.15.2 -e -system.hostfs=/hostfs`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+version: '3'
+services:
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.2
+    environment:
+      - discovery.type=single-node
+    ports:
+      - "9200:9200"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  rabbitmq:
+    image: rabbitmq:3.9-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+      - "15674:15674"
+      - "15670:15670"
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.15.2
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - "5601:5601"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    volumes:
+      - ./kibana.docker.yml:/usr/share/kibana/config/kibana.yml:ro
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5601"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  metricbeat:
+    image: docker.elastic.co/beats/metricbeat:7.17.0
+    user: root
+    environment:
+      - setup.kibana.host=kibana:5601
+      - output.elasticsearch.hosts=["http://elasticsearch:9200"]
+    volumes:
+      - ./metricbeat.docker.yml:/usr/share/metricbeat/metricbeat.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro
+      - /proc:/hostfs/proc:ro
+      - /:/hostfs:ro"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+      kibana:
+        condition: service_healthy

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-hacker

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,37 @@
+## Welcome to GitHub Pages
+
+You can use the [editor on GitHub](https://github.com/ben-newman10/fullstack-demo-push-notifications/edit/main/docs/index.md) to maintain and preview the content for your website in Markdown files.
+
+Whenever you commit to this repository, GitHub Pages will run [Jekyll](https://jekyllrb.com/) to rebuild the pages in your site, from the content in your Markdown files.
+
+### Markdown
+
+Markdown is a lightweight and easy-to-use syntax for styling your writing. It includes conventions for
+
+```markdown
+Syntax highlighted code block
+
+# Header 1
+## Header 2
+### Header 3
+
+- Bulleted
+- List
+
+1. Numbered
+2. List
+
+**Bold** and _Italic_ and `Code` text
+
+[Link](url) and ![Image](src)
+```
+
+For more details see [Basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
+
+### Jekyll Themes
+
+Your Pages site will use the layout and styles from the Jekyll theme you have selected in your [repository settings](https://github.com/ben-newman10/fullstack-demo-push-notifications/settings/pages). The name of this theme is saved in the Jekyll `_config.yml` configuration file.
+
+### Support or Contact
+
+Having trouble with Pages? Check out our [documentation](https://docs.github.com/categories/github-pages-basics/) or [contact support](https://support.github.com/contact) and we’ll help you sort it out.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,37 +1,94 @@
-## Welcome to GitHub Pages
+demo for use of WebSockets
+the idea is to allow push notifications to be sent from Elastic to the middleware (Python: FastAPI) and then on up to the UI (JavaScript: Svelte), in order to avoid the UI having to constantly poll the middleware which then has to constantly poll Elastic in response (or perform some kind of caching)
 
-You can use the [editor on GitHub](https://github.com/ben-newman10/fullstack-demo-push-notifications/edit/main/docs/index.md) to maintain and preview the content for your website in Markdown files.
+progress so far:
 
-Whenever you commit to this repository, GitHub Pages will run [Jekyll](https://jekyllrb.com/) to rebuild the pages in your site, from the content in your Markdown files.
+- UI opens a WS to the middleware, and subscribes to messages coming from it
+- UI sends a boolean down the WS to the middleware to toggle on/off each channel individually
+- MetricBeats is running, populating Elastic with system stats
+- multiple parallel independent components in the UI (each subscribed to their own backend data feed)
+- installed an Elastic plugin which pushes change notifications out on a websocket - requires Elastic and Kibana 6.5.3, so installed them also (instead of latest version 7.15.1)
+- installed the plugin into Elastic (and then restarted Elastic) which can't be done easily with Elastic running inside a Docker container (so actually installed Elastic and Kibana)
+- used default config for the plugin, to push all updates out to the WS, seems to be fine as-is (for this demo at least)
+- changed the Python code to use the WS (instead of polling Elastic)
+- totally removed the logic (to determine when the backend status has changed) as the Elastic plugin does this for us now
+- totally removed all polling of Elastic from the middleware, and all polling of the middleware from the UI
 
-### Markdown
+to start the UI:
+npm run dev
 
-Markdown is a lightweight and easy-to-use syntax for styling your writing. It includes conventions for
+to start Python server:
+cd src; uvicorn main:app
 
-```markdown
-Syntax highlighted code block
+to install **_ VERSION: 6.5.3 _** of Elastic, Kibana, Metricbeat
+echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | sudo tee –a /etc/apt/sources.list.d/elastic-6.x.list
+apt update
+apt install elasticsearch=6.5.3
+apt install kibana=6.5.3
+cd /tmp
+wget https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-6.5.3-amd64.deb
+dpkg -i /tmp/metricbeat-6.5.3-amd64.deb
 
-# Header 1
-## Header 2
-### Header 3
+to install the plugin
+git clone https://github.com/ForgeRock/es-change-feed-plugin.git
+cd es-change-feed-plugin
+mvn clean install  
+ mkdir /tmp/elasticsearch
+cp target/es-changes-feed-plugin.zip /tmp/elasticsearch
+cd /tmp/elasticsearch
+unzip es-changes-feed-plugin.zip
+cd ..
+zip -r es-changes-feed-plugin.zip elasticsearch # requires Elastic to be running first
+/usr/share/elasticsearch/bin/elasticsearch-plugin install file:///tmp/es-changes-feed-plugin.zip
+systemctl restart elastic
 
-- Bulleted
-- List
+to run the demo:
 
-1. Numbered
-2. List
+    start Python server:
+        cd src; uvicorn main:app
 
-**Bold** and _Italic_ and `Code` text
+    start the UI:
+        npm run dev
 
-[Link](url) and ![Image](src)
-```
+    start Elastic:
+        systemctl start elastic
 
-For more details see [Basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
+    start Kibana:
+        # requires Elastic to be running first
+        systemctl start kibana
 
-### Jekyll Themes
+    start  Metricbeat:
+        # requires Elastic and Kibana to be running first
+        /usr/bin/metricbeat setup -e
+        systemctl start metricbeat
 
-Your Pages site will use the layout and styles from the Jekyll theme you have selected in your [repository settings](https://github.com/ben-newman10/fullstack-demo-push-notifications/settings/pages). The name of this theme is saved in the Jekyll `_config.yml` configuration file.
+## Run all services using docker-compose
 
-### Support or Contact
+All services depicted below can be run using docker-compose:
 
-Having trouble with Pages? Check out our [documentation](https://docs.github.com/categories/github-pages-basics/) or [contact support](https://support.github.com/contact) and we’ll help you sort it out.
+- To bring up all services: `docker-compose up -d`
+- To bin down all services: `docker-compose down`
+
+### Run Elastic
+
+`docker run --memory=2gb --name es01-test --net elastic -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.15.2`
+
+### Run RabbitMQ
+
+`docker run --memory=500mb -it --rm --name rabbitmq -p 5672:5672 -p 15672:15672 -p 15674:15674 -p 15670:15670 rabbitmq:3.9-management`
+
+### Run Kibana
+
+`docker run --memory=2gb --name kib01-test --volume="$(pwd)/kibana.yml:/usr/share/kibana/config/kibana.yml:ro" --net elastic -p 5601:5601 -e "ELASTICSEARCH_HOSTS=http://es01-test:9200" docker.elastic.co/kibana/kibana:7.15.2`
+
+### Run Metricbeat
+
+`docker run --memory=500mb docker.elastic.co/beats/metricbeat:7.15.2 setup -E setup.kibana.host=< LOCAL IP >:5601 -E output.elasticsearch.hosts=["http://< LOCAL IP >:9200"]`
+
+### Run Metricbeat, with config (metricbeat.yml)
+
+`docker run --name=metricbeat --user=root --volume="$(pwd)/metricbeat.docker.yml:/usr/share/metricbeat/metricbeat.yml:ro" --volume="/var/run/docker.sock:/var/run/docker.sock:ro" --volume="/sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro" --volume="/proc:/hostfs/proc:ro" --volume="/:/hostfs:ro" docker.elastic.co/beats/metricbeat:7.15.2 metricbeat -e -E output.elasticsearch.hosts=["< LOCAL IP >:9200"]`
+
+### Tell Metricbeat to monitor the host machine
+
+`docker run --mount type=bind,source=/proc,target=/hostfs/proc,readonly --mount type=bind,source=/sys/fs/cgroup,target=/hostfs/sys/fs/cgroup,readonly --mount type=bind,source=/,target=/hostfs,readonly --net=host docker.elastic.co/beats/metricbeat:7.15.2 -e -system.hostfs=/hostfs`

--- a/kibana.docker.yml
+++ b/kibana.docker.yml
@@ -1,7 +1,7 @@
 # Default Kibana configuration for docker target
 server.host: "0"
 server.shutdownTimeout: "5s"
-elasticsearch.hosts: [ "http://192.168.1.145:9200" ]
+elasticsearch.hosts: ["http://elasticsearch:9200"]
 monitoring.ui.container.elasticsearch.enabled: true
 
 xpack.encryptedSavedObjects.encryptionKey: d30b1c0b41c9eef98d35070ec4f80bf2

--- a/metricbeat.docker.yml
+++ b/metricbeat.docker.yml
@@ -10,25 +10,24 @@ metricbeat.autodiscover:
       hints.enabled: true
 
 metricbeat.modules:
-- module: docker
-  metricsets:
-    - "container"
-    - "cpu"
-    - "diskio"
-    - "healthcheck"
-    - "info"
-    #- "image"
-    - "memory"
-    - "network"
-  hosts: ["unix:///var/run/docker.sock"]
-  period: 10s
-  enabled: true
+  - module: docker
+    metricsets:
+      - "container"
+      - "cpu"
+      - "diskio"
+      - "healthcheck"
+      - "info"
+      #- "image"
+      - "memory"
+      - "network"
+    hosts: ["unix:///var/run/docker.sock"]
+    period: 10s
+    enabled: true
 
 processors:
   - add_cloud_metadata: ~
 
 output.elasticsearch:
-  hosts: '192.168.1.145.:9200'
-  username: 'metricbeat_internal'
-  password: 'metricbeat_internal_password'
-
+  hosts: "elasticsearch:9200"
+  username: "metricbeat_internal"
+  password: "metricbeat_internal_password"


### PR DESCRIPTION
The following changes were implemented:

- A docker-compose file was created to launch all external services with a simple command.
- README.md was updated to reflect the docker-compose change.
- Various config files were changes to no longer use 'localhost' but instead connect directly to the searches they are dependant on. E.g. `kibana` & `elasticsearch`